### PR TITLE
Remove hardcoded css at layout_utils.php

### DIFF
--- a/include/utils/layout_utils.php
+++ b/include/utils/layout_utils.php
@@ -349,8 +349,9 @@ EOHTML;
     /* Fix to include files required to make pop-ups responsive */
     echo '<meta http-equiv="X-UA-Compatible" content="IE=edge">';
     echo '<meta name="viewport" content="initial-scale=1.0, user-scalable=no" />';
-    echo '<link href="themes/SuiteR/css/bootstrap.min.css" rel="stylesheet">';
-    echo '<link href="themes/SuiteR/css/colourSelector.php" rel="stylesheet">';
+    // This hardcoded both lines breaks other themes colors & styles
+    // echo '<link href="themes/SuiteR/css/bootstrap.min.css" rel="stylesheet">';
+    // echo '<link href="themes/SuiteR/css/colourSelector.php" rel="stylesheet">';
     echo '</head>';
     echo  '<body class="popupBody">';
 }


### PR DESCRIPTION
Removed hardcoded lines at layout_utils.php. This css links breaks other themes colors & styles.
